### PR TITLE
Fix use language in settings panel

### DIFF
--- a/src/components/DreameVacuumCard/DreameVacuumCard.tsx
+++ b/src/components/DreameVacuumCard/DreameVacuumCard.tsx
@@ -177,6 +177,7 @@ export function DreameVacuumCard({ hass, config }: DreameVacuumCardProps) {
         hass={hass}
         entity={entity}
         config={config}
+        language={language}
       />
 
       {toast && <Toast message={toast} onClose={hideToast} />}

--- a/src/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/components/SettingsPanel/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { Modal, Accordion } from '../common';
-import { useTranslation } from '../../hooks';
+import { useTranslation } from '../../hooks/useTranslation';
+import type { SupportedLanguage } from '../../i18n/locales';
 import { AIDetectionSection } from './sections/AIDetectionSection';
 import { CarpetSettingsSection } from './sections/CarpetSettingsSection';
 import { ConsumablesSection } from './sections/ConsumablesSection';
@@ -8,6 +9,7 @@ import { MapManagementSection } from './sections/MapManagementSection';
 import { QuickSettingsSection } from './sections/QuickSettingsSection';
 import { VolumeSection } from './sections/VolumeSection';
 import { Brain, Gauge, Info, Layers, Map, Settings2, Volume2 } from 'lucide-react';
+
 import type { Hass, HassEntity, HassConfig } from '../../types/homeassistant';
 import './SettingsPanel.scss';
 
@@ -17,10 +19,11 @@ interface SettingsPanelProps {
   hass: Hass;
   entity: HassEntity;
   config: HassConfig;
+  language?: SupportedLanguage;
 }
 
-export function SettingsPanel({ opened, onClose, hass, entity, config }: SettingsPanelProps) {
-  const { t } = useTranslation();
+export function SettingsPanel({ opened, onClose, hass, entity, config, language }: SettingsPanelProps) {
+  const { t } = useTranslation(language);
 
   return (
     <Modal opened={opened} onClose={onClose}>
@@ -30,31 +33,31 @@ export function SettingsPanel({ opened, onClose, hass, entity, config }: Setting
         <div className="settings-panel__scroll-wrapper">
           <div className="settings-panel__sections">
             <Accordion title={t('settings.consumables.title')} icon={<Gauge />} defaultOpen>
-              <ConsumablesSection hass={hass} entity={entity} />
+              <ConsumablesSection hass={hass} entity={entity} language={language} />
             </Accordion>
 
             <Accordion title={t('settings.device_info.title')} icon={<Info />}>
-              <DeviceInfoSection entity={entity} />
+              <DeviceInfoSection entity={entity} language={language} />
             </Accordion>
 
             <Accordion title={t('settings.map_management.title')} icon={<Map />}>
-              <MapManagementSection hass={hass} entity={entity} config={config} />
+              <MapManagementSection hass={hass} entity={entity} config={config} language={language} />
             </Accordion>
 
             <Accordion title={t('settings.volume.title')} icon={<Volume2 />}>
-              <VolumeSection hass={hass} entity={entity} />
+              <VolumeSection hass={hass} entity={entity} language={language} />
             </Accordion>
 
             <Accordion title={t('settings.quick_settings.title')} icon={<Settings2 />}>
-              <QuickSettingsSection hass={hass} entity={entity} />
+              <QuickSettingsSection hass={hass} entity={entity} language={language} />
             </Accordion>
 
             <Accordion title={t('settings.carpet.title')} icon={<Layers />}>
-              <CarpetSettingsSection hass={hass} entity={entity} />
+              <CarpetSettingsSection hass={hass} entity={entity} language={language} />
             </Accordion>
 
             <Accordion title={t('settings.ai_detection.title')} icon={<Brain />}>
-              <AIDetectionSection hass={hass} entity={entity} />
+              <AIDetectionSection hass={hass} entity={entity} language={language} />
             </Accordion>
           </div>
         </div>

--- a/src/components/SettingsPanel/sections/AIDetectionSection.tsx
+++ b/src/components/SettingsPanel/sections/AIDetectionSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { Toggle } from '../../common';
 import { useTranslation } from '../../../hooks';
+import type { SupportedLanguage } from '../../../i18n/locales';
 import { isBoolean, isNumber } from '../../../utils';
 import type { Hass, HassEntity } from '../../../types/homeassistant';
 import './AIDetectionSection.scss';
@@ -8,6 +9,7 @@ import './AIDetectionSection.scss';
 interface AIDetectionSectionProps {
   hass: Hass;
   entity: HassEntity;
+  language?: SupportedLanguage;
 }
 
 interface AIToggle {
@@ -91,8 +93,8 @@ const AI_TOGGLES: AIToggle[] = [
   },
 ];
 
-export function AIDetectionSection({ hass, entity }: AIDetectionSectionProps) {
-  const { t } = useTranslation();
+export function AIDetectionSection({ hass, entity, language }: AIDetectionSectionProps) {
+  const { t } = useTranslation(language);
   const attributes = entity.attributes;
   const entityName = entity.entity_id.split('.')[1] ?? '';
 

--- a/src/components/SettingsPanel/sections/CarpetSettingsSection.tsx
+++ b/src/components/SettingsPanel/sections/CarpetSettingsSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { Toggle } from '../../common';
 import { useTranslation } from '../../../hooks';
+import type { SupportedLanguage } from '../../../i18n/locales';
 import { getAttr, isBoolean, isNumber, isString } from '../../../utils';
 import type { Hass, HassEntity } from '../../../types/homeassistant';
 import './CarpetSettingsSection.scss';
@@ -8,6 +9,7 @@ import './CarpetSettingsSection.scss';
 interface CarpetSettingsSectionProps {
   hass: Hass;
   entity: HassEntity;
+  language?: SupportedLanguage;
 }
 
 interface CarpetToggle {
@@ -44,8 +46,8 @@ const CARPET_TOGGLES: CarpetToggle[] = [
 
 const CARPET_SENSITIVITY_OPTIONS = ['low', 'medium', 'high'] as const;
 
-export function CarpetSettingsSection({ hass, entity }: CarpetSettingsSectionProps) {
-  const { t } = useTranslation();
+export function CarpetSettingsSection({ hass, entity, language }: CarpetSettingsSectionProps) {
+  const { t } = useTranslation(language);
   const attributes = entity.attributes;
   const entityName = entity.entity_id.split('.')[1] ?? '';
 

--- a/src/components/SettingsPanel/sections/ConsumablesSection.tsx
+++ b/src/components/SettingsPanel/sections/ConsumablesSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from '../../../hooks';
+import type { SupportedLanguage } from '../../../i18n/locales';
 import { getAttr } from '../../../utils';
 import type { Hass, HassEntity } from '../../../types/homeassistant';
 import './ConsumablesSection.scss';
@@ -7,6 +8,7 @@ import './ConsumablesSection.scss';
 interface ConsumablesSectionProps {
   hass: Hass;
   entity: HassEntity;
+  language?: SupportedLanguage;
 }
 
 interface ConsumableItem {
@@ -48,8 +50,8 @@ const CONSUMABLES: ConsumableItem[] = [
   },
 ];
 
-export function ConsumablesSection({ hass, entity }: ConsumablesSectionProps) {
-  const { t } = useTranslation();
+export function ConsumablesSection({ hass, entity, language }: ConsumablesSectionProps) {
+  const { t } = useTranslation(language);
   const attributes = entity.attributes;
 
   const handleReset = useCallback(

--- a/src/components/SettingsPanel/sections/DeviceInfoSection.tsx
+++ b/src/components/SettingsPanel/sections/DeviceInfoSection.tsx
@@ -1,10 +1,12 @@
 import { useTranslation } from '../../../hooks';
+import type { SupportedLanguage } from '../../../i18n/locales';
 import { getAttr, isString, isNumber } from '../../../utils';
 import type { HassEntity } from '../../../types/homeassistant';
 import './DeviceInfoSection.scss';
 
 interface DeviceInfoSectionProps {
   entity: HassEntity;
+  language?: SupportedLanguage;
 }
 
 interface InfoItem {
@@ -13,8 +15,8 @@ interface InfoItem {
   unit?: string;
 }
 
-export function DeviceInfoSection({ entity }: DeviceInfoSectionProps) {
-  const { t } = useTranslation();
+export function DeviceInfoSection({ entity, language }: DeviceInfoSectionProps) {
+  const { t } = useTranslation(language);
   const attributes = entity.attributes;
 
   const rawFirmware = attributes.firmware_version;

--- a/src/components/SettingsPanel/sections/MapManagementSection.tsx
+++ b/src/components/SettingsPanel/sections/MapManagementSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from '../../../hooks';
+import type { SupportedLanguage } from '../../../i18n/locales';
 import type { Hass, HassEntity, HassConfig } from '../../../types/homeassistant';
 import './MapManagementSection.scss';
 
@@ -7,6 +8,7 @@ interface MapManagementSectionProps {
   hass: Hass;
   entity: HassEntity;
   config: HassConfig;
+  language?: SupportedLanguage;
 }
 
 interface MapInfo {
@@ -14,8 +16,8 @@ interface MapInfo {
   name: string;
 }
 
-export function MapManagementSection({ hass, entity, config }: MapManagementSectionProps) {
-  const { t } = useTranslation();
+export function MapManagementSection({ hass, entity, config, language }: MapManagementSectionProps) {
+  const { t } = useTranslation(language);
   const attributes = entity.attributes;
 
   // Get available maps from entity attributes

--- a/src/components/SettingsPanel/sections/QuickSettingsSection.tsx
+++ b/src/components/SettingsPanel/sections/QuickSettingsSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { Toggle } from '../../common';
 import { useTranslation } from '../../../hooks';
+import type { SupportedLanguage } from '../../../i18n/locales';
 import { isBoolean, isNumber, isObject } from '../../../utils';
 import type { Hass, HassEntity } from '../../../types/homeassistant';
 import './QuickSettingsSection.scss';
@@ -8,6 +9,7 @@ import './QuickSettingsSection.scss';
 interface QuickSettingsSectionProps {
   hass: Hass;
   entity: HassEntity;
+  language?: SupportedLanguage;
 }
 
 interface QuickSetting {
@@ -56,8 +58,8 @@ const QUICK_SETTINGS: QuickSetting[] = [
   },
 ];
 
-export function QuickSettingsSection({ hass, entity }: QuickSettingsSectionProps) {
-  const { t } = useTranslation();
+export function QuickSettingsSection({ hass, entity, language }: QuickSettingsSectionProps) {
+  const { t } = useTranslation(language);
   const attributes = entity.attributes;
   const entityName = entity.entity_id.split('.')[1] ?? '';
 

--- a/src/components/SettingsPanel/sections/VolumeSection.tsx
+++ b/src/components/SettingsPanel/sections/VolumeSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { Volume2, VolumeX, MapPin } from 'lucide-react';
 import { useTranslation } from '../../../hooks';
+import type { SupportedLanguage } from '../../../i18n/locales';
 import { getAttr } from '../../../utils';
 import type { Hass, HassEntity } from '../../../types/homeassistant';
 import './VolumeSection.scss';
@@ -8,13 +9,14 @@ import './VolumeSection.scss';
 interface VolumeSectionProps {
   hass: Hass;
   entity: HassEntity;
+  language?: SupportedLanguage;
 }
 
 const VOLUME_MIN = 0;
 const VOLUME_MAX = 100;
 
-export function VolumeSection({ hass, entity }: VolumeSectionProps) {
-  const { t } = useTranslation();
+export function VolumeSection({ hass, entity, language }: VolumeSectionProps) {
+  const { t } = useTranslation(language);
   const entityName = entity.entity_id.split('.')[1] ?? '';
   const currentVolume = getAttr(entity.attributes.volume, 50);
 


### PR DESCRIPTION
I don't know if it was intentional or accidental, but you forgot to enable variable translation in the settings panel. I'm not very good at TypeScript, but it's easy to hack it. Please review my request; I think I did everything correctly.