### PR TITLE
Add French translation

### DIFF
--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1,11 +1,13 @@
-export const fr = {
-  // Sélecteur de pièces
+import type { Translation } from './en';
+
+export const fr: Translation = {
+  // Room selector
   room_selector: {
     title: 'Sélectionner des pièces',
     selected_count: '{{count}} sélectionnée(s)',
   },
 
-  // Carte de l'aspirateur
+  // Vacuum map
   vacuum_map: {
     no_map: 'Aucune carte disponible',
     looking_for: 'Recherche de : {{entity}}',
@@ -16,17 +18,17 @@ export const fr = {
     switch_to_list: 'Passer à la vue liste',
     switch_to_map: 'Passer à la vue carte',
     room_list_overlay: 'Appuyez sur les pièces pour les sélectionner',
-    no_rooms: 'Aucune pièce disponible',
+    no_rooms: 'Aucune pièce configurée',
   },
 
-  // Onglets de mode
+  // Mode tabs
   modes: {
     room: 'Pièce',
     all: 'Tout',
     zone: 'Zone',
   },
 
-  // Boutons d'action
+  // Action buttons
   actions: {
     clean: 'Nettoyer',
     clean_all: 'Tout nettoyer',
@@ -37,10 +39,10 @@ export const fr = {
     pause: 'Pause',
     resume: 'Reprendre',
     stop: 'Arrêter',
-    dock: 'Base',
+    dock: 'Chargement',
   },
 
-  // Messages Toast
+  // Toast messages
   toast: {
     selected_room: '{{name}} sélectionné(e)',
     deselected_room: '{{name}} désélectionné(e)',
@@ -61,13 +63,13 @@ export const fr = {
     select_zone_first: 'Veuillez sélectionner une zone sur la carte',
   },
 
-  // Affichage de la sélection des pièces
+  // Room selection display
   room_display: {
     selected_rooms: 'Pièces sélectionnées :',
     selected_label: 'Sélection :',
   },
 
-  // Bouton de mode de nettoyage
+  // Cleaning mode button
   cleaning_mode_button: {
     prefix_custom: 'Personnalisé : ',
     prefix_cleangenius: 'CleanGenius : ',
@@ -78,40 +80,40 @@ export const fr = {
     mop: 'Serpillère',
   },
 
-  // Modal de mode de nettoyage
+  // Cleaning mode modal
   cleaning_mode: {
     title: 'Mode de nettoyage',
     clean_genius: 'CleanGenius',
     custom: 'Personnalisé',
   },
 
-  // Modal de raccourcis
+  // Shortcuts modal
   shortcuts: {
     title: 'Raccourcis',
     no_shortcuts: 'Aucun raccourci disponible',
     create_hint: 'Créez des raccourcis dans l\'application Dreame pour lancer rapidement vos routines préférées',
   },
 
-  // Mode personnalisé
+  // Custom mode
   custom_mode: {
     cleaning_mode_title: 'Mode de nettoyage',
     suction_power_title: 'Puissance d\'aspiration',
     max_plus_description: 'La puissance sera augmentée au niveau maximum (usage unique).',
-    wetness_title: 'Humidité',
-    slightly_dry: 'Légèrement sec',
-    moist: 'Humide',
-    wet: 'Mouillé',
+    wetness_title: 'Débit d\'eau',
+    slightly_dry: 'Sec',
+    moist: 'Standard',
+    wet: 'Humide',
     mop_washing_frequency_title: 'Fréquence de lavage de serpillère',
-    route_title: 'Trajectoire',
+    route_title: 'Trajectoire de nettoyage',
   },
 
-  // Mode CleanGenius
+  // CleanGenius mode
   cleangenius_mode: {
     cleaning_mode_title: 'Mode de nettoyage',
     deep_cleaning: 'Nettoyage approfondi',
   },
 
-  // En-tête
+  // Header
   header: {
     battery: 'Batterie',
     status: 'Statut',
@@ -119,7 +121,7 @@ export const fr = {
     time: 'Temps',
   },
 
-  // Unités
+  // Units
   units: {
     square_meters: 'm²',
     minutes: 'min',
@@ -128,28 +130,28 @@ export const fr = {
     decibels: 'dBm',
   },
 
-  // Niveaux d'aspiration
+  // Suction levels
   suction_levels: {
     quiet: 'Silencieux',
     standard: 'Standard',
-    strong: 'Turbo',
-    turbo: 'Max',
+    strong: 'Fort',
+    turbo: 'Turbo',
   },
 
-  // Fréquence de lavage
+  // Mop washing frequency
   mop_washing_frequency: {
     by_room: 'Par pièce',
     by_area: 'Par surface',
     by_time: 'Par durée',
   },
 
-  // Erreurs
+  // Errors
   errors: {
     entity_not_found: 'Entité introuvable : {{entity}}',
     failed_to_load: 'Échec du chargement des données',
   },
 
-  // Panneau de paramètres
+  // Settings panel
   settings: {
     title: 'Paramètres',
     consumables: {
@@ -163,7 +165,7 @@ export const fr = {
     },
     device_info: {
       title: 'Infos appareil',
-      firmware: 'Firmware',
+      firmware: 'Version du firmware',
       total_area: 'Surface totale nettoyée',
       total_time: 'Temps total de nettoyage',
       total_cleans: 'Nombre total de nettoyages',
@@ -178,22 +180,22 @@ export const fr = {
     },
     quick_settings: {
       title: 'Réglages rapides',
-      child_lock: 'Sécurité enfant',
+      child_lock: 'Verrouillage enfant',
       child_lock_desc: 'Désactiver les boutons physiques',
       carpet_boost: 'Boost tapis',
       carpet_boost_desc: 'Augmenter l\'aspiration sur les tapis',
       obstacle_avoidance: 'Évitement d\'obstacles',
       obstacle_avoidance_desc: 'Éviter les objets durant le nettoyage',
-      auto_dust_collecting: 'Vidage auto',
+      auto_dust_collecting: 'Vidage automatique',
       auto_dust_collecting_desc: 'Vider automatiquement le bac à poussière',
-      auto_drying: 'Séchage auto',
+      auto_drying: 'Séchage automatique',
       auto_drying_desc: 'Sécher la serpillère après nettoyage',
       dnd: 'Ne pas déranger',
       dnd_desc: 'Heures silencieuses avec activité réduite',
     },
     volume: {
       title: 'Volume & Son',
-      test_sound: 'Localiser',
+      test_sound: 'Localiser l\'aspirateur',
       muted: 'Muet',
     },
     carpet: {
@@ -211,7 +213,7 @@ export const fr = {
       sensitivity_high: 'Élevée',
     },
     ai_detection: {
-      title: 'IA & Détection',
+      title: 'AI & Detection',
       obstacle_avoidance: 'Évitement d\'obstacles',
       obstacle_avoidance_desc: 'Utiliser les capteurs pour éviter les obstacles',
       ai_obstacle_detection: 'Détection d\'obstacles par IA',
@@ -235,5 +237,3 @@ export const fr = {
     },
   },
 };
-
-export type Translation = typeof fr;

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1,0 +1,239 @@
+export const fr = {
+  // Sélecteur de pièces
+  room_selector: {
+    title: 'Sélectionner des pièces',
+    selected_count: '{{count}} sélectionnée(s)',
+  },
+
+  // Carte de l'aspirateur
+  vacuum_map: {
+    no_map: 'Aucune carte disponible',
+    looking_for: 'Recherche de : {{entity}}',
+    room_overlay: 'Cliquez sur les numéros pour sélectionner les pièces à nettoyer',
+    zone_overlay_create: 'Cliquez sur la carte pour placer une zone de nettoyage',
+    zone_overlay_resize: 'Faites glisser les coins pour redimensionner, cliquez ailleurs pour repositionner',
+    clear_zone: 'Effacer la zone',
+    switch_to_list: 'Passer à la vue liste',
+    switch_to_map: 'Passer à la vue carte',
+    room_list_overlay: 'Appuyez sur les pièces pour les sélectionner',
+    no_rooms: 'Aucune pièce disponible',
+  },
+
+  // Onglets de mode
+  modes: {
+    room: 'Pièce',
+    all: 'Tout',
+    zone: 'Zone',
+  },
+
+  // Boutons d'action
+  actions: {
+    clean: 'Nettoyer',
+    clean_all: 'Tout nettoyer',
+    clean_rooms: 'Nettoyer {{count}} pièce',
+    clean_rooms_plural: 'Nettoyer {{count}} pièces',
+    select_rooms: 'Sélectionner des pièces',
+    zone_clean: 'Nettoyage de zone',
+    pause: 'Pause',
+    resume: 'Reprendre',
+    stop: 'Arrêter',
+    dock: 'Base',
+  },
+
+  // Messages Toast
+  toast: {
+    selected_room: '{{name}} sélectionné(e)',
+    deselected_room: '{{name}} désélectionné(e)',
+    paused: 'Nettoyage mis en pause',
+    stopped: 'Nettoyage arrêté',
+    docked: 'Retour à la base',
+    cleaning_started: 'Nettoyage démarré',
+    resuming: 'Reprise du nettoyage',
+    starting_full_clean: 'Démarrage du nettoyage complet',
+    pausing_vacuum: 'Mise en pause de l\'aspirateur',
+    stopping_vacuum: 'Arrêt de l\'aspirateur',
+    vacuum_docking: 'L\'aspirateur retourne à sa base',
+    starting_room_clean: 'Démarrage du nettoyage de la pièce sélectionnée',
+    starting_room_clean_plural: 'Démarrage du nettoyage des {{count}} pièces sélectionnées',
+    starting_zone_clean: 'Démarrage du nettoyage de zone',
+    select_rooms_first: 'Veuillez d\'abord sélectionner des pièces',
+    cannot_determine_map: 'Impossible de déterminer les dimensions de la carte',
+    select_zone_first: 'Veuillez sélectionner une zone sur la carte',
+  },
+
+  // Affichage de la sélection des pièces
+  room_display: {
+    selected_rooms: 'Pièces sélectionnées :',
+    selected_label: 'Sélection :',
+  },
+
+  // Bouton de mode de nettoyage
+  cleaning_mode_button: {
+    prefix_custom: 'Personnalisé : ',
+    prefix_cleangenius: 'CleanGenius : ',
+    view_shortcuts: 'Voir les raccourcis',
+    vac_and_mop: 'Aspi & Lavage',
+    mop_after_vac: 'Lavage après Aspi',
+    vacuum: 'Aspirateur',
+    mop: 'Serpillère',
+  },
+
+  // Modal de mode de nettoyage
+  cleaning_mode: {
+    title: 'Mode de nettoyage',
+    clean_genius: 'CleanGenius',
+    custom: 'Personnalisé',
+  },
+
+  // Modal de raccourcis
+  shortcuts: {
+    title: 'Raccourcis',
+    no_shortcuts: 'Aucun raccourci disponible',
+    create_hint: 'Créez des raccourcis dans l\'application Dreame pour lancer rapidement vos routines préférées',
+  },
+
+  // Mode personnalisé
+  custom_mode: {
+    cleaning_mode_title: 'Mode de nettoyage',
+    suction_power_title: 'Puissance d\'aspiration',
+    max_plus_description: 'La puissance sera augmentée au niveau maximum (usage unique).',
+    wetness_title: 'Humidité',
+    slightly_dry: 'Légèrement sec',
+    moist: 'Humide',
+    wet: 'Mouillé',
+    mop_washing_frequency_title: 'Fréquence de lavage de serpillère',
+    route_title: 'Trajectoire',
+  },
+
+  // Mode CleanGenius
+  cleangenius_mode: {
+    cleaning_mode_title: 'Mode de nettoyage',
+    deep_cleaning: 'Nettoyage approfondi',
+  },
+
+  // En-tête
+  header: {
+    battery: 'Batterie',
+    status: 'Statut',
+    area: 'Surface',
+    time: 'Temps',
+  },
+
+  // Unités
+  units: {
+    square_meters: 'm²',
+    minutes: 'min',
+    minutes_short: 'm',
+    percent: '%',
+    decibels: 'dBm',
+  },
+
+  // Niveaux d'aspiration
+  suction_levels: {
+    quiet: 'Silencieux',
+    standard: 'Standard',
+    strong: 'Turbo',
+    turbo: 'Max',
+  },
+
+  // Fréquence de lavage
+  mop_washing_frequency: {
+    by_room: 'Par pièce',
+    by_area: 'Par surface',
+    by_time: 'Par durée',
+  },
+
+  // Erreurs
+  errors: {
+    entity_not_found: 'Entité introuvable : {{entity}}',
+    failed_to_load: 'Échec du chargement des données',
+  },
+
+  // Panneau de paramètres
+  settings: {
+    title: 'Paramètres',
+    consumables: {
+      title: 'Consommables',
+      main_brush: 'Brosse principale',
+      side_brush: 'Brosse latérale',
+      filter: 'Filtre',
+      sensor: 'Capteur',
+      remaining: 'restant',
+      reset: 'Réinitialiser',
+    },
+    device_info: {
+      title: 'Infos appareil',
+      firmware: 'Firmware',
+      total_area: 'Surface totale nettoyée',
+      total_time: 'Temps total de nettoyage',
+      total_cleans: 'Nombre total de nettoyages',
+      wifi_ssid: 'Réseau Wi-Fi',
+      wifi_signal: 'Force du signal',
+      ip_address: 'Adresse IP',
+    },
+    map_management: {
+      title: 'Gestion des cartes',
+      description: 'Sélectionnez la carte à utiliser.',
+      no_maps: 'Aucune carte disponible',
+    },
+    quick_settings: {
+      title: 'Réglages rapides',
+      child_lock: 'Sécurité enfant',
+      child_lock_desc: 'Désactiver les boutons physiques',
+      carpet_boost: 'Boost tapis',
+      carpet_boost_desc: 'Augmenter l\'aspiration sur les tapis',
+      obstacle_avoidance: 'Évitement d\'obstacles',
+      obstacle_avoidance_desc: 'Éviter les objets durant le nettoyage',
+      auto_dust_collecting: 'Vidage auto',
+      auto_dust_collecting_desc: 'Vider automatiquement le bac à poussière',
+      auto_drying: 'Séchage auto',
+      auto_drying_desc: 'Sécher la serpillère après nettoyage',
+      dnd: 'Ne pas déranger',
+      dnd_desc: 'Heures silencieuses avec activité réduite',
+    },
+    volume: {
+      title: 'Volume & Son',
+      test_sound: 'Localiser',
+      muted: 'Muet',
+    },
+    carpet: {
+      title: 'Paramètres tapis',
+      carpet_boost: 'Boost tapis',
+      carpet_boost_desc: 'Puissance max sur les tapis',
+      carpet_recognition: 'Reconnaissance de tapis',
+      carpet_recognition_desc: 'Détecter automatiquement les tapis',
+      carpet_avoidance: 'Évitement de tapis',
+      carpet_avoidance_desc: 'Ne pas passer sur les tapis avec la serpillère',
+      sensitivity: 'Sensibilité tapis',
+      sensitivity_desc: 'Niveau de sensibilité de détection',
+      sensitivity_low: 'Faible',
+      sensitivity_medium: 'Moyenne',
+      sensitivity_high: 'Élevée',
+    },
+    ai_detection: {
+      title: 'IA & Détection',
+      obstacle_avoidance: 'Évitement d\'obstacles',
+      obstacle_avoidance_desc: 'Utiliser les capteurs pour éviter les obstacles',
+      ai_obstacle_detection: 'Détection d\'obstacles par IA',
+      ai_obstacle_detection_desc: 'Utiliser l\'IA pour identifier les obstacles',
+      ai_obstacle_image_upload: 'Envoi d\'images d\'obstacles',
+      ai_obstacle_image_upload_desc: 'Envoyer les images pour analyse',
+      ai_pet_detection: 'Détection d\'animaux',
+      ai_pet_detection_desc: 'Détecter et éviter les animaux',
+      ai_human_detection: 'Détection humaine',
+      ai_human_detection_desc: 'Détecter et éviter les personnes',
+      ai_furniture_detection: 'Détection de meubles',
+      ai_furniture_detection_desc: 'Naviguer autour des meubles',
+      ai_fluid_detection: 'Détection de liquides',
+      ai_fluid_detection_desc: 'Détecter et éviter les flaques',
+      stain_avoidance: 'Évitement des taches',
+      stain_avoidance_desc: 'Éviter les taches détectées',
+      collision_avoidance: 'Évitement de collision',
+      collision_avoidance_desc: 'Prévenir les chocs avec les objets',
+      fill_light: 'Lumière d\'appoint',
+      fill_light_desc: 'Utiliser la lumière pour une meilleure détection',
+    },
+  },
+};
+
+export type Translation = typeof fr;

--- a/src/i18n/locales/fr_FR.ts
+++ b/src/i18n/locales/fr_FR.ts
@@ -1,6 +1,6 @@
 import type { Translation } from './en';
 
-export const fr: Translation = {
+export const fr_FR: Translation = {
   // Room selector
   room_selector: {
     title: 'Sélectionner des pièces',

--- a/src/i18n/locales/fr_FR.ts
+++ b/src/i18n/locales/fr_FR.ts
@@ -1,6 +1,6 @@
 import type { Translation } from './en';
 
-export const fr: Translation = {
+export const fr_FR: Translation = {
   // Room selector
   room_selector: {
     title: 'Sélectionner des pièces',
@@ -213,7 +213,7 @@ export const fr: Translation = {
       sensitivity_high: 'Élevée',
     },
     ai_detection: {
-      title: 'AI & Detection',
+      title: 'IA & Détection',
       obstacle_avoidance: 'Évitement d\'obstacles',
       obstacle_avoidance_desc: 'Utiliser les capteurs pour éviter les obstacles',
       ai_obstacle_detection: 'Détection d\'obstacles par IA',

--- a/src/i18n/locales/fr_FR.ts
+++ b/src/i18n/locales/fr_FR.ts
@@ -1,10 +1,15 @@
 import type { Translation } from './en';
 
-export const fr_FR: Translation = {
+export const fr: Translation = {
   // Room selector
   room_selector: {
     title: 'Sélectionner des pièces',
     selected_count: '{{count}} sélectionnée(s)',
+  },
+
+  // Map Selector
+  map_selector: {
+    unknown: 'Carte inconnue',
   },
 
   // Vacuum map
@@ -19,6 +24,11 @@ export const fr_FR: Translation = {
     switch_to_map: 'Passer à la vue carte',
     room_list_overlay: 'Appuyez sur les pièces pour les sélectionner',
     no_rooms: 'Aucune pièce configurée',
+    zoom_in: 'Zoom avant',
+    zoom_out: 'Zoom arrière',
+    zoom_reset: 'Réinitialiser le zoom',
+    lock_map: 'Verrouiller la carte',
+    unlock_map: 'Déverrouiller la carte',
   },
 
   // Mode tabs
@@ -39,7 +49,8 @@ export const fr_FR: Translation = {
     pause: 'Pause',
     resume: 'Reprendre',
     stop: 'Arrêter',
-    dock: 'Chargement',
+    stop_and_dock: 'Arrêter et charger',
+    dock: 'Charger',
   },
 
   // Toast messages
@@ -52,13 +63,14 @@ export const fr_FR: Translation = {
     cleaning_started: 'Nettoyage démarré',
     resuming: 'Reprise du nettoyage',
     starting_full_clean: 'Démarrage du nettoyage complet',
-    pausing_vacuum: 'Mise en pause de l\'aspirateur',
-    stopping_vacuum: 'Arrêt de l\'aspirateur',
-    vacuum_docking: 'L\'aspirateur retourne à sa base',
+    pausing_vacuum: "Mise en pause de l'aspirateur",
+    stopping_vacuum: "Arrêt de l'aspirateur",
+    stopping_and_docking: 'Arrêt et retour à la base',
+    vacuum_docking: "L'aspirateur retourne à sa base",
     starting_room_clean: 'Démarrage du nettoyage de la pièce sélectionnée',
     starting_room_clean_plural: 'Démarrage du nettoyage des {{count}} pièces sélectionnées',
     starting_zone_clean: 'Démarrage du nettoyage de zone',
-    select_rooms_first: 'Veuillez d\'abord sélectionner des pièces',
+    select_rooms_first: "Veuillez d'abord sélectionner des pièces",
     cannot_determine_map: 'Impossible de déterminer les dimensions de la carte',
     select_zone_first: 'Veuillez sélectionner une zone sur la carte',
   },
@@ -74,6 +86,7 @@ export const fr_FR: Translation = {
     prefix_custom: 'Personnalisé : ',
     prefix_cleangenius: 'CleanGenius : ',
     view_shortcuts: 'Voir les raccourcis',
+    repeats_tooltip: 'Passages de nettoyage',
     vac_and_mop: 'Aspi & Lavage',
     mop_after_vac: 'Lavage après Aspi',
     vacuum: 'Aspirateur',
@@ -91,20 +104,37 @@ export const fr_FR: Translation = {
   shortcuts: {
     title: 'Raccourcis',
     no_shortcuts: 'Aucun raccourci disponible',
-    create_hint: 'Créez des raccourcis dans l\'application Dreame pour lancer rapidement vos routines préférées',
+    create_hint: "Créez des raccourcis dans l'application Dreame pour lancer rapidement vos routines préférées",
   },
 
   // Custom mode
   custom_mode: {
     cleaning_mode_title: 'Mode de nettoyage',
-    suction_power_title: 'Puissance d\'aspiration',
+    suction_power_title: "Puissance d'aspiration",
     max_plus_description: 'La puissance sera augmentée au niveau maximum (usage unique).',
-    wetness_title: 'Débit d\'eau',
+    wetness_title: "Débit d'eau",
     slightly_dry: 'Sec',
     moist: 'Standard',
     wet: 'Humide',
     mop_washing_frequency_title: 'Fréquence de lavage de serpillère',
     route_title: 'Trajectoire de nettoyage',
+  },
+
+  // Customize Cleaning Mode
+  customize: {
+    title: 'Personnaliser',
+    description: "Définir les préférences d'aspiration et de lavage pour chaque zone.",
+    set_button: 'Définir',
+    vacuum: 'Aspirateur',
+    mop: 'Serpillère',
+    vac_and_mop: 'Aspi & Lavage',
+    cycles: 'Cycles',
+    apply_to_all: 'Appliquer à toutes les pièces',
+    click_room_hint: 'Cliquez sur une zone pour changer le mode.',
+    intelligent_recommendation: 'Recommandation intelligente',
+    select_room: 'Sélectionner une pièce',
+    settings_for: 'Paramètres de {{room}}',
+    no_rooms: 'Aucune pièce disponible',
   },
 
   // CleanGenius mode
@@ -145,6 +175,14 @@ export const fr_FR: Translation = {
     by_time: 'Par durée',
   },
 
+  // Cleaning Routes
+  cleaning_routes: {
+    quick: 'Rapide',
+    standard: 'Standard',
+    intensive: 'Intensif',
+    deep: 'Profond',
+  },
+
   // Errors
   errors: {
     entity_not_found: 'Entité introuvable : {{entity}}',
@@ -183,8 +221,8 @@ export const fr_FR: Translation = {
       child_lock: 'Verrouillage enfant',
       child_lock_desc: 'Désactiver les boutons physiques',
       carpet_boost: 'Boost tapis',
-      carpet_boost_desc: 'Augmenter l\'aspiration sur les tapis',
-      obstacle_avoidance: 'Évitement d\'obstacles',
+      carpet_boost_desc: "Augmenter l'aspiration sur les tapis",
+      obstacle_avoidance: "Évitement d'obstacles",
       obstacle_avoidance_desc: 'Éviter les objets durant le nettoyage',
       auto_dust_collecting: 'Vidage automatique',
       auto_dust_collecting_desc: 'Vider automatiquement le bac à poussière',
@@ -195,7 +233,7 @@ export const fr_FR: Translation = {
     },
     volume: {
       title: 'Volume & Son',
-      test_sound: 'Localiser l\'aspirateur',
+      test_sound: "Localiser l'aspirateur",
       muted: 'Muet',
     },
     carpet: {
@@ -214,13 +252,13 @@ export const fr_FR: Translation = {
     },
     ai_detection: {
       title: 'IA & Détection',
-      obstacle_avoidance: 'Évitement d\'obstacles',
+      obstacle_avoidance: "Évitement d'obstacles",
       obstacle_avoidance_desc: 'Utiliser les capteurs pour éviter les obstacles',
-      ai_obstacle_detection: 'Détection d\'obstacles par IA',
-      ai_obstacle_detection_desc: 'Utiliser l\'IA pour identifier les obstacles',
-      ai_obstacle_image_upload: 'Envoi d\'images d\'obstacles',
+      ai_obstacle_detection: "Détection d'obstacles par IA",
+      ai_obstacle_detection_desc: "Utiliser l'IA pour identifier les obstacles",
+      ai_obstacle_image_upload: "Envoi d'images d'obstacles",
       ai_obstacle_image_upload_desc: 'Envoyer les images pour analyse',
-      ai_pet_detection: 'Détection d\'animaux',
+      ai_pet_detection: "Détection d'animaux",
       ai_pet_detection_desc: 'Détecter et éviter les animaux',
       ai_human_detection: 'Détection humaine',
       ai_human_detection_desc: 'Détecter et éviter les personnes',
@@ -232,8 +270,21 @@ export const fr_FR: Translation = {
       stain_avoidance_desc: 'Éviter les taches détectées',
       collision_avoidance: 'Évitement de collision',
       collision_avoidance_desc: 'Prévenir les chocs avec les objets',
-      fill_light: 'Lumière d\'appoint',
+      fill_light: "Lumière d'appoint",
       fill_light_desc: 'Utiliser la lumière pour une meilleure détection',
+    },
+    station_controls: {
+      title: 'Contrôles de la station',
+      self_clean: 'Auto-nettoyage',
+      self_clean_desc: 'Démarrer le cycle de lavage de la serpillère',
+      manual_drying: 'Séchage manuel',
+      manual_drying_desc: 'Démarrer le cycle de séchage de la serpillère',
+      water_tank_draining: 'Vidange du réservoir',
+      water_tank_draining_desc: "Vidanger l'eau sale du réservoir",
+      base_station_cleaning: 'Nettoyage de la station',
+      base_station_cleaning_desc: 'Nettoyer la station de base',
+      empty_water_tank: 'Vider le réservoir',
+      empty_water_tank_desc: "Vider le réservoir de collecte d'eau",
     },
   },
 };

--- a/src/i18n/locales/index.ts
+++ b/src/i18n/locales/index.ts
@@ -6,6 +6,7 @@ import { es } from './es';
 import { nl } from './nl';
 import { it } from './it';
 import { pl } from './pl';
+import { fr } from './fr';
 
 export const locales = {
   en,
@@ -16,6 +17,7 @@ export const locales = {
   nl,
   it,
   pl,
+  fr,
 };
 
 export type SupportedLanguage = keyof typeof locales;

--- a/src/i18n/locales/index.ts
+++ b/src/i18n/locales/index.ts
@@ -6,7 +6,7 @@ import { es } from './es';
 import { nl } from './nl';
 import { it } from './it';
 import { pl } from './pl';
-import { fr } from './fr';
+import { fr_FR } from './fr';
 
 export const locales = {
   en,
@@ -17,7 +17,7 @@ export const locales = {
   nl,
   it,
   pl,
-  fr,
+  fr_FR,
 };
 
 export type SupportedLanguage = keyof typeof locales;

--- a/src/i18n/locales/index.ts
+++ b/src/i18n/locales/index.ts
@@ -6,7 +6,7 @@ import { es } from './es';
 import { nl } from './nl';
 import { it } from './it';
 import { pl } from './pl';
-import { fr_FR } from './fr';
+import { fr_FR } from './fr_FR';
 import { he } from './he';
 
 export const locales = {

--- a/src/types/homeassistant.ts
+++ b/src/types/homeassistant.ts
@@ -54,7 +54,7 @@ export interface HassConfig {
   type: string;
   theme?: 'light' | 'dark' | 'custom';
   custom_theme?: CustomThemeConfig;
-  language?: 'en' | 'de' | 'ru' | 'pl' | 'it' | 'nl' | 'es' | 'zh';
+  language?: 'en' | 'de' | 'ru' | 'pl' | 'it' | 'nl' | 'es' | 'zh' | 'fr'; 
   default_mode?: CleaningMode;
   default_room_view?: RoomViewMode;
 }

--- a/src/types/homeassistant.ts
+++ b/src/types/homeassistant.ts
@@ -54,7 +54,7 @@ export interface HassConfig {
   type: string;
   theme?: 'light' | 'dark' | 'custom';
   custom_theme?: CustomThemeConfig;
-  language?: 'en' | 'de' | 'ru' | 'pl' | 'it' | 'nl' | 'es' | 'zh' | 'fr'; 
+  language?: 'en' | 'de' | 'ru' | 'pl' | 'it' | 'nl' | 'es' | 'zh' | 'fr_FR'; 
   default_mode?: CleaningMode;
   default_room_view?: RoomViewMode;
 }

--- a/src/types/homeassistant.ts
+++ b/src/types/homeassistant.ts
@@ -54,7 +54,7 @@ export interface HassConfig {
   type: string;
   theme?: 'light' | 'dark' | 'custom';
   custom_theme?: CustomThemeConfig;
-  language?: 'en' | 'de' | 'ru' | 'pl' | 'it' | 'nl' | 'es' | 'zh'| 'he' | 'fr_FR';
+  language?: 'en' | 'de' | 'ru' | 'pl' | 'it' | 'nl' | 'es' | 'zh' | 'he' | 'fr_FR';
   default_mode?: CleaningMode;
   default_room_view?: RoomViewMode;
 }


### PR DESCRIPTION
Add French translation
This pull request adds a French (fr.ts) locale file for the Dreame Vacuum Map Card.
The file contains translated interface labels and messages to improve usability for French-speaking users.

Changes

Added source/fr.ts

Updated translation index and configuration types to support the 'fr' language option.

Translated UI labels and messages.

Notes
The translations were created based on the existing locale structure and terminology from the Dreamehome app.

Please let me know if any changes or improvements are needed.
