### PR TITLE
adjust height of .cleaning-mode-modal

### DIFF
--- a/src/components/CleaningModeModal/CleaningModeModal.scss
+++ b/src/components/CleaningModeModal/CleaningModeModal.scss
@@ -8,7 +8,7 @@
   }
 
   &__content-wrapper {
-    height: calc(100% - 4rem);
+    height: 100%;
     overflow-y: auto;
     width: 100%;
     overflow-x: hidden;


### PR DESCRIPTION
Currently, the labels of the third row are cut off, and there's a needless scrollbar as a result.
And I do not see a reason for what is effectively a `margin-bottom: 4rem`. To me, the padding seems correct without it.

Before & After
<img width="467" height="456" alt="image" src="https://github.com/user-attachments/assets/1cde6e18-9a2a-4c1b-b6a0-8fa5127f449e" />
<img width="467" height="456" alt="image" src="https://github.com/user-attachments/assets/a44563f3-10cc-4091-b6df-a8f0fdba4189" />
(I duplicated the 3rd row so that the cutoff point is more visible. And I tested the scrolling with it, of course.)
