### PR TITLE
feat: auto-detect light/dark theme from Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A modern, beautiful Home Assistant Lovelace card for controlling Dreame robot va
 - CleanGenius and Custom cleaning mode configuration
 - **Per-room customized cleaning**: Configure suction level, wetness, and cleaning cycles for each room individually
 - Real-time vacuum status and battery level
-- **Customizable Theming**: Light, dark, and fully customizable themes
+- **Customizable Theming**: Auto light/dark (follows your Home Assistant theme), plus fully customizable themes
 - **Internationalization (i18n)**: Multiple language support (English, German, Russian, Polish, Italian, Dutch, Spanish, Chinese, Hebrew) with RTL support
 
 <div style="display: flex; gap: 10px;">
@@ -88,7 +88,7 @@ type: custom:dreame-vacuum-map-card
 entity: vacuum.dreame_vacuum_entity
 title: Dreame Vacuum
 map_entity: camera.dreame_vacuum_entity # Optional, defaults to camera.${ENTITY_NAME}_map
-theme: light # Optional, 'light' (default), 'dark', or 'custom'
+theme: auto # Optional, 'auto' (default, follows Home Assistant's light/dark mode), 'light', 'dark', or 'custom'
 language: en # Optional, 'en' (default) or 'de'
 default_mode: all # Optional, 'all' (default), 'room', or 'zone'
 default_room_view: map # Optional, 'map' (default) or 'list'
@@ -107,7 +107,17 @@ The card features a comprehensive theming system with built-in and custom theme 
 
 ### Built-in Themes
 
-#### Light Theme (Default)
+#### Auto (Default)
+
+Automatically follows Home Assistant's active light/dark mode, so the card switches theme whenever your dashboard does (e.g. a day/night schedule).
+
+```yaml
+type: custom:dreame-vacuum-map-card
+entity: vacuum.dreame_vacuum_entity
+theme: auto
+```
+
+#### Light Theme
 
 ```yaml
 type: custom:dreame-vacuum-map-card

--- a/src/components/DreameVacuumCard/DreameVacuumCard.tsx
+++ b/src/components/DreameVacuumCard/DreameVacuumCard.tsx
@@ -28,7 +28,10 @@ interface DreameVacuumCardProps {
 export function DreameVacuumCard({ hass, config }: DreameVacuumCardProps) {
   const entity = hass.states[config.entity];
   logger.debug('DreameVacuumCard', 'Loaded entity', entity);
-  const themeType = config.theme || 'light';
+  // Default to 'auto': follow Home Assistant's active light/dark mode.
+  // Users can still force 'light' | 'dark' | 'custom' via config.
+  const configuredTheme = config.theme || 'auto';
+  const themeType = configuredTheme === 'auto' ? (hass.themes?.darkMode ? 'dark' : 'light') : configuredTheme;
   const language = config.language || 'en';
   const isRtl = isRtlLanguage(language as SupportedLanguage);
   const { t } = useTranslation(language);

--- a/src/types/homeassistant.ts
+++ b/src/types/homeassistant.ts
@@ -57,7 +57,7 @@ export interface HassConfig {
   map_entity?: string;
   title?: string;
   type: string;
-  theme?: 'light' | 'dark' | 'custom';
+  theme?: 'auto' | 'light' | 'dark' | 'custom';
   custom_theme?: CustomThemeConfig;
   language?: 'en' | 'de' | 'ru' | 'pl' | 'it' | 'nl' | 'es' | 'zh' | 'he' | 'fr_FR' | 'ko';
   default_mode?: CleaningSelectionMode;
@@ -83,6 +83,9 @@ export interface Hass {
   hassUrl: (path: string) => string;
   config?: {
     unit_system?: HassUnitSystem;
+  };
+  themes?: {
+    darkMode?: boolean;
   };
 }
 

--- a/src/utils/typeGuards.ts
+++ b/src/utils/typeGuards.ts
@@ -94,7 +94,7 @@ export const configSchema = z.object({
   entity: vacuumEntitySchema,
   map_entity: cameraEntitySchema.optional(),
   title: z.string().optional(),
-  theme: z.enum(['light', 'dark', 'custom']).optional(),
+  theme: z.enum(['auto', 'light', 'dark', 'custom']).optional(),
   custom_theme: customThemeSchema,
   language: z.enum(['en', 'de', 'ru', 'pl', 'it', 'nl', 'es', 'zh', 'he', 'fr_FR', 'ko']).optional(),
   default_mode: z.enum(['room', 'all', 'zone']).optional(),


### PR DESCRIPTION
Default config.theme to 'auto', which follows hass.themes.darkMode instead of always rendering in light mode. Explicit 'light' | 'dark' | 'custom' values in config.theme still override this.