### PR TITLE
fix(map): scale the map to fit instead of cropping it, and let users rename/resize room labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,24 @@ map_overlays: # Experimental Optional, list of overlays to show on the map
   - room_labels # Show room names
   - vacuum # Show vacuum position marker
   - charger # Show charger position marker
+map_height: 520px # Optional, cap the map height (any CSS length). The map is scaled to fit, never cropped.
+room_label_scale: 0.6 # Optional, 1 = default label size. Useful when the labels cover the rooms.
+room_names: # Optional, override the room names shown by the card
+  1: Bedroom # Key: segment id from the map camera's `rooms` attribute …
+  Kitchen: Kitchenette # … or the name the device reports
 buttons: # Optional
   - type: stop # Only stop button is supported
     action: stop # 'stop' (default), 'stop_and_dock'
 ```
+
+### Renaming rooms
+
+Dreame devices only report room names from a fixed catalogue, and that catalogue is
+English-only regardless of the `language` setting. `room_names` overrides the display
+name everywhere the card shows it — map labels, room list, selection summary, per-room
+settings and toasts. Keys are looked up as segment id first, then as the device-provided
+name; anything not listed keeps its original name. Cleaning commands always use the
+segment id, so renaming is purely cosmetic.
 
 ## Theming
 

--- a/src/components/CleaningModeModal/CustomizeMode.tsx
+++ b/src/components/CleaningModeModal/CustomizeMode.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { CircularButton, Accordion } from '@/components/common';
 import { useTranslation, useRoomSettings, getEntityState } from '@/hooks';
-import { useHass, useIsRtl } from '@/contexts';
+import { useHass, useIsRtl, useConfig } from '@/contexts';
 import { parseRoomsFromCamera } from '@/utils/roomParser';
 import {
   SUCTION_QUIET_ICON_SVG,
@@ -309,10 +309,11 @@ function RoomSettingsContent({
 export function CustomizeMode({ baseEntityId }: CustomizeModeProps) {
   const { t } = useTranslation();
   const hass = useHass();
+  const config = useConfig();
 
   // Get map entity ID and parse rooms
   const mapEntityId = buildEntityId('camera', baseEntityId, DREAME_CAMERAS.MAP.key);
-  const rooms = parseRoomsFromCamera(hass, mapEntityId);
+  const rooms = parseRoomsFromCamera(hass, mapEntityId, config.room_names);
 
   // Use room settings hook to read/write HA entities
   const { roomSettings, setSuctionLevel, setWetnessLevel, setCleaningTimes, setMopPressure, setMopTemperature } =

--- a/src/components/DreameVacuumCard/DreameVacuumCard.tsx
+++ b/src/components/DreameVacuumCard/DreameVacuumCard.tsx
@@ -17,6 +17,7 @@ import { CAPABILITY } from '@/constants';
 import type { Hass, HassConfig } from '@/types/homeassistant';
 import type { SupportedLanguage } from '@/i18n/locales';
 import { useState, useRef, useEffect, useCallback } from 'react';
+import type { CSSProperties } from 'react';
 import { logger } from '@/utils/logger';
 import './DreameVacuumCard.scss';
 
@@ -79,7 +80,7 @@ export function DreameVacuumCard({ hass, config }: DreameVacuumCardProps) {
   useEffect(() => {
     if (!isSegmentCleaning) return;
 
-    const activeSegments = getActiveSegments(hass, config.entity, mapEntityId);
+    const activeSegments = getActiveSegments(hass, config.entity, mapEntityId, config.room_names);
     if (activeSegments.size > 0) {
       // Only update if different from current selection
       const currentIds = Array.from(selectedRooms.keys()).sort();
@@ -92,7 +93,16 @@ export function DreameVacuumCard({ hass, config }: DreameVacuumCardProps) {
         setSelectedMode('room');
       }
     }
-  }, [isSegmentCleaning, hass, config.entity, mapEntityId, selectedRooms, setSelectedRooms, setSelectedMode]);
+  }, [
+    isSegmentCleaning,
+    hass,
+    config.entity,
+    config.room_names,
+    mapEntityId,
+    selectedRooms,
+    setSelectedRooms,
+    setSelectedMode,
+  ]);
 
   // Reset repeat count when vacuum stops cleaning
   useEffect(() => {
@@ -199,6 +209,7 @@ export function DreameVacuumCard({ hass, config }: DreameVacuumCardProps) {
         ref={containerRef}
         className={`dreame-vacuum-card dreame-vacuum-card--${theme.name}`}
         dir={isRtl ? 'rtl' : 'ltr'}
+        style={config.map_height ? ({ '--map-max-height': config.map_height } as CSSProperties) : undefined}
       >
         <div className="dreame-vacuum-card__container">
           <Header deviceName={deviceName} onSettingsClick={handleSettingsOpen} />

--- a/src/components/VacuumMap/RoomLabels.tsx
+++ b/src/components/VacuumMap/RoomLabels.tsx
@@ -8,10 +8,18 @@ interface RoomLabelsProps {
   calibrationPoints: CalibrationPoint[];
   imageWidth: number;
   imageHeight: number;
+  /** Scale factor for the label size, 1 = default. Clamped to a sane range. */
+  scale?: number;
 }
 
-export function RoomLabels({ rooms, calibrationPoints, imageWidth, imageHeight }: RoomLabelsProps) {
-  const fontSize = Math.max(imageWidth, imageHeight) * 0.025;
+// Label height as a fraction of the map's longer edge at scale 1.
+const BASE_FONT_RATIO = 0.025;
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 3;
+
+export function RoomLabels({ rooms, calibrationPoints, imageWidth, imageHeight, scale = 1 }: RoomLabelsProps) {
+  const safeScale = Number.isFinite(scale) ? Math.min(Math.max(scale, MIN_SCALE), MAX_SCALE) : 1;
+  const fontSize = Math.max(imageWidth, imageHeight) * BASE_FONT_RATIO * safeScale;
   const paddingX = fontSize * 0.6;
   const paddingY = fontSize * 0.4;
   const borderRadius = fontSize * 0.5;

--- a/src/components/VacuumMap/VacuumMap.scss
+++ b/src/components/VacuumMap/VacuumMap.scss
@@ -9,13 +9,24 @@
   box-shadow: 0 0.25rem 0.9375rem var(--card-shadow, rgba(0, 0, 0, 0.1));
   min-height: 18.75rem;
 
+  // Height budget for the map picture. The cap used to sit on this container while
+  // the image kept its width-driven height, so a tall map was simply cut off by
+  // `overflow: hidden`. It now caps the image instead (see `&__image`), which scales
+  // the whole map down to fit rather than cropping it.
+  --map-max-height-fallback: none;
+
   // Landscape orientation: constrain map height to fit within viewport
   // This prevents scrolling on tablets/displays in landscape mode
   // 280px accounts for: header (~80px) + controls (~150px) + padding (~50px)
   @media (orientation: landscape) {
-    max-height: calc(100vh - 280px);
-    max-height: calc(100dvh - 280px); // Use dynamic viewport height where supported
+    --map-max-height-fallback: calc(100vh - 280px);
+
     min-height: min(18.75rem, calc(100vh - 280px)); // Don't enforce min-height larger than available space
+
+    // Use dynamic viewport height where supported
+    @supports (height: 100dvh) {
+      --map-max-height-fallback: calc(100dvh - 280px);
+    }
   }
 
   // Locked state: allow page scrolling through the map
@@ -33,10 +44,18 @@
     height: 100%;
   }
 
+  // `object-fit: contain` letterboxes the picture inside the capped box. The overlay
+  // SVGs (room labels, segments, vacuum/charger markers) use viewBox +
+  // `preserveAspectRatio="xMidYMid meet"` on the same box, which letterboxes the same
+  // way — so they stay pixel-aligned with the map at any cap.
+  // `--map-max-height` comes from the card's `map_height` option and wins over the
+  // viewport-derived fallback.
   &__image {
     display: block;
     width: 100%;
     height: auto;
+    max-height: var(--map-max-height, var(--map-max-height-fallback, none));
+    object-fit: contain;
     border-radius: 0.9375rem;
     user-select: none;
     -webkit-user-drag: none;

--- a/src/components/VacuumMap/VacuumMap.tsx
+++ b/src/components/VacuumMap/VacuumMap.tsx
@@ -131,9 +131,9 @@ export function VacuumMap({
 
   // Memoize parsed rooms to avoid recalculation on every render
   const parsedRooms = useMemo(
-    () => parseRoomsFromCamera(hass, mapEntityId),
+    () => parseRoomsFromCamera(hass, mapEntityId, config.room_names),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hass.states[mapEntityId]?.attributes?.rooms, mapEntityId]
+    [hass.states[mapEntityId]?.attributes?.rooms, mapEntityId, config.room_names]
   );
   const calibrationPoints = (mapEntity?.attributes?.calibration_points as CalibrationPoint[] | undefined) ?? [];
 
@@ -251,6 +251,7 @@ export function VacuumMap({
                   calibrationPoints={calibrationPoints}
                   imageWidth={imageDimensions.width}
                   imageHeight={imageDimensions.height}
+                  scale={config.room_label_scale}
                 />
               )}
 

--- a/src/types/homeassistant.ts
+++ b/src/types/homeassistant.ts
@@ -64,6 +64,12 @@ export interface HassConfig {
   default_room_view?: RoomViewMode;
   buttons?: ButtonConfig[];
   map_overlays?: MapOverlay[];
+  /** Display-name overrides for rooms, keyed by segment id or by the device-provided name. */
+  room_names?: Record<string, string>;
+  /** Scale factor for the room labels drawn on the map (1 = unchanged). */
+  room_label_scale?: number;
+  /** Maximum height of the map area as a CSS length, e.g. '520px' or '60vh'. */
+  map_height?: string;
 }
 
 export interface HassUnitSystem {

--- a/src/utils/entityHelpers.ts
+++ b/src/utils/entityHelpers.ts
@@ -1,5 +1,6 @@
 import type { HassEntity, HassConfig, RoomPosition, CleaningSelectionMode, Hass, Room } from '@/types/homeassistant';
 import { getAttr } from './typeGuards';
+import { resolveRoomName } from './roomParser';
 
 export function resolveMapEntityId(hass: Hass, vacuumEntityId: string, configMapEntity?: string): string {
   if (configMapEntity) {
@@ -87,7 +88,12 @@ export function getEffectiveCleaningMode(
  * Get active segments from vacuum entity when segment cleaning is in progress.
  * Returns a Map of roomId -> roomName for the currently cleaning segments.
  */
-export function getActiveSegments(hass: Hass, vacuumEntityId: string, cameraEntityId: string): Map<number, string> {
+export function getActiveSegments(
+  hass: Hass,
+  vacuumEntityId: string,
+  cameraEntityId: string,
+  roomNames?: Record<string, string>
+): Map<number, string> {
   const vacuumEntity = hass.states[vacuumEntityId];
   const cameraEntity = hass.states[cameraEntityId];
   const result = new Map<number, string>();
@@ -107,7 +113,7 @@ export function getActiveSegments(hass: Hass, vacuumEntityId: string, cameraEnti
 
   if (roomsData) {
     Object.values(roomsData).forEach((room) => {
-      roomNameById.set(room.room_id, room.name);
+      roomNameById.set(room.room_id, resolveRoomName(room.room_id, room.name, roomNames));
     });
   }
 

--- a/src/utils/roomParser.ts
+++ b/src/utils/roomParser.ts
@@ -100,7 +100,19 @@ function autoCalibrateFromRooms(
   }
 }
 
-export function parseRoomsFromCamera(hass: Hass, cameraEntityId: string): Room[] {
+/**
+ * Resolve the display name of a room.
+ *
+ * Dreame devices only expose room names from a fixed English catalogue, so the card
+ * lets users override them via the `room_names` config option. Lookup order:
+ * segment id first (stable across renames), then the device-provided name.
+ */
+export function resolveRoomName(roomId: number, deviceName: string, roomNames?: Record<string, string>): string {
+  if (!roomNames) return deviceName;
+  return roomNames[String(roomId)] ?? roomNames[deviceName] ?? deviceName;
+}
+
+export function parseRoomsFromCamera(hass: Hass, cameraEntityId: string, roomNames?: Record<string, string>): Room[] {
   const cameraEntity = hass.states[cameraEntityId];
   if (!cameraEntity?.attributes?.rooms) {
     logger.debug('RoomParser', 'No rooms found in camera entity:', cameraEntityId);
@@ -111,7 +123,7 @@ export function parseRoomsFromCamera(hass: Hass, cameraEntityId: string): Room[]
 
   return Object.values(roomsData).map((room) => ({
     id: room.room_id,
-    name: room.name,
+    name: resolveRoomName(room.room_id, room.name, roomNames),
     icon: room.icon,
     visibility: room.visibility,
     x0: room.x0,

--- a/src/utils/typeGuards.ts
+++ b/src/utils/typeGuards.ts
@@ -100,6 +100,10 @@ export const configSchema = z.object({
   default_mode: z.enum(['room', 'all', 'zone']).optional(),
   default_room_view: z.enum(['map', 'list']).optional(),
   buttons: z.array(buttonConfigSchema).optional(),
+  map_overlays: z.array(z.enum(['vacuum', 'charger', 'room_labels'])).optional(),
+  room_names: z.record(z.string(), z.string()).optional(),
+  room_label_scale: z.number().positive().optional(),
+  map_height: z.string().optional(),
 });
 
 export type ValidatedConfig = z.infer<typeof configSchema>;


### PR DESCRIPTION
# fix(map): scale the map to fit instead of cropping it, and let users rename/resize room labels

Two independent commits. The first is a self-contained bug fix, the second adds three config options. Happy to split this into two PRs if you prefer.

---

## 1. The map is cropped, not zoomed out — `fix(map)`

Fixes #78

**Symptom (from #78):** on tablet/PC the map does not fit, while the same card in a phone-width window fits correctly. The follow-up comment on that issue ("my map-zoom, its way too big") is the same thing.

**Root cause.** The height cap sits on the *container*, which clips:

```scss
.vacuum-map {
  overflow: hidden;

  @media (orientation: landscape) {
    max-height: calc(100dvh - 280px);
  }

  &__image {
    width: 100%;
    height: auto; // ← still scales off the width, ignores the cap
  }
}
```

The image keeps deriving its height from the container width, so whatever exceeds the cap is simply cut off. That also explains why the issue is landscape-only: in portrait the media query never applies, so nothing clips and the map looks right.

How much disappears depends on the map's aspect ratio, which is why this went unnoticed for a while — on my instance the Tasshack integration re-rendered the map from 608×916 to 604×1096 after a rescan, and the crop went from "barely noticeable" to "a chunk of the flat is missing".

**Fix.** Move the cap onto the `<img>` and letterbox with `object-fit: contain`. The four overlays (room labels, room segments, vacuum and charger markers) already render as SVGs with `viewBox` + `preserveAspectRatio="xMidYMid meet"` on the same box, so they letterbox by exactly the same rule and stay pixel-aligned with the picture — no coordinate math needed.

The viewport-derived value is kept as the fallback, so default behaviour is unchanged apart from fitting instead of clipping.

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/ManuelStaggl/dreame-vacuum-map-card/assets/pr-94/docs/pr-94/pr-fit-before.png" width="380"> | <img src="https://raw.githubusercontent.com/ManuelStaggl/dreame-vacuum-map-card/assets/pr-94/docs/pr-94/pr-fit-after.png" width="380"> |

Same browser session, same device state, same viewport (1600×800), same 465×520 map area — the only difference is the CSS: the "before" shot has the old rule injected back as a `<style>` into the shadow root. Four of the eight rooms are simply gone in the cropped version.

## 2. Room names, label size, explicit map height — `feat(config)`

### `room_names` — addresses #69

Dreame reports room names from a fixed English catalogue, and #69 shows the catch: names customised in the Dreame app are not synced back through the integration, so `language:` cannot help — the strings simply never reach the card in the user's language.

`room_names` overrides the display name wherever the card shows one: map labels, room list, selection summary, per-room settings and toasts. Resolution happens in one place (`resolveRoomName()` in `roomParser.ts`), so no call site can drift.

```yaml
room_names:
  1: Schlafzimmer # segment id — preferred, matches select.<device>_room_<id>_* entities
  Kitchen: Küche  # or the device-provided name
```

Keys resolve as segment id first, then as the device name; anything unlisted keeps its original name. Cleaning commands are untouched — `segments` has always been built from ids, never from names, so this is purely cosmetic.

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/ManuelStaggl/dreame-vacuum-map-card/assets/pr-94/docs/pr-94/pr-map-before.png" width="380"> | <img src="https://raw.githubusercontent.com/ManuelStaggl/dreame-vacuum-map-card/assets/pr-94/docs/pr-94/pr-map-after.png" width="380"> |

Both at a 1920px viewport, in a half-width dashboard column. "after" also has `room_label_scale: 0.6` — at the default size the labels cover the rooms they name, and "Primary Bedroom" is wide enough to reach into the next room.

### `room_label_scale`

Label size is `max(imageWidth, imageHeight) * 0.025`. That is reasonable for a full-width card, but once the card sits in a narrow dashboard column the labels cover the rooms they name. The option scales that base value and is clamped to 0.2–3.

### `map_height`

Any CSS length, overrides the viewport-derived cap via a CSS variable. Useful when the card is not the only thing on screen and `100dvh - 280px` is not the right budget.

### Also

`map_overlays` was declared in `HassConfig` but missing from the Zod schema, so it was never validated. Added alongside the new keys.

## Testing

- `npm run build` (tsc + vite), `npm run lint`, `npm run lint:scss` — all clean
- Live on a Dreame Aqua10 Ultra Roller (`dreame.vacuum.r9547a`, Tasshack v2.0.0b25, HA 2026.8.1), map 604×1096, 8 segments
- Verified at desktop 1920px and mobile 390px: whole map visible in both, overlays aligned with the picture, room labels German, zero card errors and a clean browser console
- Not exercised live: the `getActiveSegments()` path, which supplies the names for the selection row when the dashboard is reloaded *during* a segment clean. It goes through the same `resolveRoomName()` as the verified map labels, but I could not trigger `segment_cleaning: true` at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
